### PR TITLE
Update paginator.py

### DIFF
--- a/sqlalchemy_paginator/paginator.py
+++ b/sqlalchemy_paginator/paginator.py
@@ -172,6 +172,8 @@ class Paginator(object):
             if self.optional_count_query_set is None:
                 self.optional_count_query_set = self.query_set.order_by(None)
             count_query = self.optional_count_query_set.statement.with_only_columns([func.count()])
+            if self.optional_count_query_set._group_by:
+                count_query = count_query.alias().count()
             self.__count = self.optional_count_query_set.session.execute(count_query).scalar()
         return self.__count
     count = property(__get_count)


### PR DESCRIPTION
if there has a group_by() in the query, the Paginator.__get_count will just return the first group's count. To fix this.