### PR TITLE
Import error in the sqlalchemy-paginator/paginator.py

### DIFF
--- a/sqlalchemy_paginator/paginator.py
+++ b/sqlalchemy_paginator/paginator.py
@@ -6,7 +6,7 @@ Created on Oct 20, 2015
 from math import ceil
 from sqlalchemy import func
 
-from exceptions import PageNotAnInteger, EmptyPage
+from .exceptions import PageNotAnInteger, EmptyPage
 
 
 class Paginator(object):


### PR DESCRIPTION
The exceptions here are imported from within the directory not from any library